### PR TITLE
Update ancestral hash

### DIFF
--- a/lib/duck_puncher/ancestral_hash.rb
+++ b/lib/duck_puncher/ancestral_hash.rb
@@ -1,0 +1,8 @@
+module DuckPuncher
+  # @note When updating this file please update comment regarding this module in duck_puncher.rb
+  module AncestralHash
+    def ancestral_hash
+      ::Hash.new { |me, klass| me[me.keys.detect { |key| key > klass }] if klass }
+    end
+  end
+end

--- a/lib/duck_puncher/decoration.rb
+++ b/lib/duck_puncher/decoration.rb
@@ -1,4 +1,5 @@
 module DuckPuncher
+  # @note When updating this file please update comment regarding this module in duck_puncher.rb
   module Decoration
     def decorators
       @decorators ||= ancestral_hash
@@ -18,7 +19,7 @@ module DuckPuncher
 
     def cached_decorators
       @cached_decorators ||= Hash.new do |me, target|
-        me[target] = DuckPuncher.decorators.select { |klass, _| klass >= target }.sort { |a, b| b[0] <=> a[0] }
+        me[target] = DuckPuncher.decorators.select { |klass, _| klass >= target }
       end
     end
 

--- a/lib/duck_puncher/defaults.rb
+++ b/lib/duck_puncher/defaults.rb
@@ -1,0 +1,20 @@
+DuckPuncher.logger = Logger.new(STDOUT).tap do |config|
+  config.formatter = proc { |*args| "[#{args[1]}] #{args[0]}: #{args[-1]}\n" }
+  config.level = Logger::ERROR
+end
+
+ducks = [
+  [String, DuckPuncher::Ducks::String],
+  [Enumerable, DuckPuncher::Ducks::Enumerable],
+  [Array, DuckPuncher::Ducks::Enumerable],
+  [Hash, DuckPuncher::Ducks::Enumerable],
+  [Numeric, DuckPuncher::Ducks::Numeric],
+  [Hash, DuckPuncher::Ducks::Hash],
+  [Object, DuckPuncher::Ducks::Object],
+  [Module, DuckPuncher::Ducks::Module],
+  [Method, DuckPuncher::Ducks::Method, { before: ->(_target) { DuckPuncher::GemInstaller.initialize! } }],
+]
+ducks << ['ActiveRecord::Base', DuckPuncher::Ducks::ActiveRecord] if defined? ::ActiveRecord
+ducks.each do |duck|
+  DuckPuncher.register *duck
+end

--- a/lib/duck_puncher/duck.rb
+++ b/lib/duck_puncher/duck.rb
@@ -2,7 +2,6 @@ module DuckPuncher
   class Duck
     attr_accessor :target, :mod, :options
 
-    # @todo test punching a module
     # @param target [String,Class] Class or module to punch
     # @param mod [String,Module] The module that defines the extensions (@name is used by default)
     # @param [Hash] options to modify the duck #punch method behavior
@@ -20,14 +19,14 @@ module DuckPuncher
     # @option options [Symbol,String] :method Specifies if the methods should be included or prepended (:include)
     # @return [Class] The class that was just punched
     def punch(opts = {})
-      target = opts.delete(:target) || self.target
-      Array(target).each do |klass|
-        options[:before].call(klass) if options[:before]
-        klass.extend Usable
-        klass.usable mod, only: opts[:only], method: opts[:method]
-        options[:after].call(klass) if options[:after]
+      targets = Array(opts.delete(:target) || self.target)
+      targets.each do |target|
+        options[:before].call(target) if options[:before]
+        target.extend Usable
+        target.usable mod, only: opts[:only], method: opts[:method]
+        options[:after].call(target) if options[:after]
       end
-      target
+      targets
     end
 
     #

--- a/lib/duck_puncher/ducks.rb
+++ b/lib/duck_puncher/ducks.rb
@@ -1,7 +1,7 @@
 module DuckPuncher
   module Ducks
     autoload :String, 'duck_puncher/ducks/string'
-    autoload :Array, 'duck_puncher/ducks/array'
+    autoload :Enumerable, 'duck_puncher/ducks/enumerable'
     autoload :Numeric, 'duck_puncher/ducks/numeric'
     autoload :Hash, 'duck_puncher/ducks/hash'
     autoload :Object, 'duck_puncher/ducks/object'

--- a/lib/duck_puncher/ducks/enumerable.rb
+++ b/lib/duck_puncher/ducks/enumerable.rb
@@ -1,6 +1,6 @@
 module DuckPuncher
   module Ducks
-    module Array
+    module Enumerable
       def m(method_name)
         map(&method_name)
       end

--- a/lib/duck_puncher/registration.rb
+++ b/lib/duck_puncher/registration.rb
@@ -1,4 +1,5 @@
 module DuckPuncher
+  # @note When updating this file please update comment regarding this module in duck_puncher.rb
   module Registration
     def register(target, *mods)
       options = mods.last.is_a?(Hash) ? mods.pop : {}

--- a/lib/duck_puncher/utilities.rb
+++ b/lib/duck_puncher/utilities.rb
@@ -1,0 +1,23 @@
+module DuckPuncher
+  # @note When updating this file please update comment regarding this module in duck_puncher.rb
+  module Utilities
+    def lookup_constant(const)
+      return const if ::Module === const
+      if const.to_s.respond_to?(:constantize)
+        const.to_s.constantize
+      else
+        const.to_s.split('::').inject(::Object) { |k, part| k.const_get(part) }
+      end
+    rescue ::NameError => e
+      log.error "#{e.class}: #{e.message}"
+      nil
+    end
+
+    def redefine_constant(name, const)
+      if const_defined? name
+        remove_const name
+      end
+      const_set name, const
+    end
+  end
+end

--- a/test/lib/duck_puncher_test.rb
+++ b/test/lib/duck_puncher_test.rb
@@ -6,7 +6,6 @@ class DuckPuncherTest < MiniTest::Test
   def setup
     @subject = Animal.new
     @kaia = Kaia.new
-    DuckPuncher.deregister Animal, Kaia, Dog
   end
 
   def teardown
@@ -23,7 +22,7 @@ class DuckPuncherTest < MiniTest::Test
   end
 
   def test_punch_all!
-    DuckPuncher.punch_all!
+    DuckPuncher.()
     expected_methods = DuckPuncher::Ducks.list.values.m(:to_a).flatten.m(:mod).m(:local_methods).flatten
     assert expected_methods.size > 1
     good_ducks = DuckPuncher::Ducks.list.select { |_, ducks|
@@ -37,6 +36,7 @@ class DuckPuncherTest < MiniTest::Test
     expected_methods = DuckPuncher::Ducks.list.values.m(:to_a).flatten.m(:mod).m(:local_methods).flatten
     assert expected_methods.size > 1
     good_ducks = DuckPuncher::Ducks.list.select { |_, ducks|
+      # Assert that all methods were copied over
       ducks.all? { |duck| (duck.mod.local_methods - duck.target.instance_methods(:false)).size.zero? }
     }
     assert good_ducks.size > 5


### PR DESCRIPTION
Switch standard Array duck to Enumerable. Still works with Array, because it checks ancestors better. Some reorganization as well
